### PR TITLE
fix: Correct API data mappings for search and details

### DIFF
--- a/app/grants/page.tsx
+++ b/app/grants/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata, ResolvingMetadata } from 'next';
 import GrantsPageClient from "./GrantsPageClient";
 import { searchGrants } from "@/app/services/grantsGovService"; // Using alias
 import type { Grant } from "@/types"; // Using alias
@@ -25,6 +26,7 @@ export async function generateMetadata(
       url: `/grants${searchTerm ? `?q=${encodeURIComponent(searchTerm)}` : ''}`,
       description: `Search results for ${searchTerm || 'all available grants'}.`,
     },
+    // Twitter card can also be customized or inherited
   };
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,22 +15,16 @@ export interface Grant {
 }
 
 export interface GrantsGovGrant {
-  opportunityId: string; 
-  opportunityNumber: string; 
-  opportunityTitle: string; 
-  agencyName: string; 
-  postDate: string | null; 
-  closeDate: string | null; 
-  oppStatus?: string; 
-  cfdaNumbers: string[]; 
-  description?: string;
-  awardCeiling?: string; 
-  eligibleApplicants?: string[];
-  link?: string;
-  keywords?: string[];
-  fundingInstrumentType?: string;
-  opportunityCategory?: string;
-  // Removed agencyCode and docType as per instructions
+  id: string; // e.g., "219999"
+  number: string; // e.g., "TEST-ABC-20231011-OPP1"
+  title: string;
+  agencyCode: string;
+  agencyName: string;
+  openDate: string | null; // e.g., "10/11/2023"
+  closeDate: string | null;
+  oppStatus: string; // e.g., "posted"
+  docType: string; // e.g., "synopsis"
+  alnist: string[]; // e.g., ["93.223"]
 }
 
 export interface GrantsGovResponseData {


### PR DESCRIPTION
Aligns Grant object mapping with official Grants.gov API documentation for both `search2` (oppHits) and `fetchOpportunity` endpoints.

- Updates `GrantsGovGrant` type in `types/index.ts` to accurately reflect fields from `search2` `oppHits` (id, number, title, etc.).
- Modifies `_mapOppHitToGrant` service function to use correct field names from `oppHits` and use placeholders for unavailable data like full description or amount.
- Updates `_mapFetchedOpportunityToGrant` service function to correctly parse the nested structure of the `fetchOpportunity` response (data object, synopsis object) and map fields like description, eligibility, categories, amount, dates accurately.
- Adjusts `getGrantDetails` to correctly pass the full API response to the detail mapper.

These changes should resolve inaccuracies in data display and issues like the "No featured grants found" error if caused by incorrect data parsing after successful API calls.