### PR TITLE
fix: Refine 'Apply Here' link on grant detail page

### DIFF
--- a/app/services/grantsGovService.ts
+++ b/app/services/grantsGovService.ts
@@ -114,18 +114,15 @@ function _mapFetchedOpportunityToGrant(apiDetailResponse: any): Grant {
   }
 
   // LinkToApply generation
-  let applyLink = 'https://www.grants.gov'; // Default fallback if no valid ID
+  let applyLink = 'https://www.grants.gov'; // Default fallback
+  const directLinkFromApi = synopsis?.link; // From fetchOpportunity sample: data.synopsis.link
   const oppId = grantData?.opportunityId?.toString();
 
-  // Check if a direct link is provided in synopsis (based on old mapping, though new sample didn't show it for details page)
-  // If synopsis.link is a field that can appear in fetchOpportunity details, prioritize it.
-  // For now, assuming it's not typically there for the main apply/view link based on the latest 'fetchOpportunity' sample.
-  // If it were:
-  // if (synopsis?.link) {
-  //   applyLink = synopsis.link;
-  // } else 
-  if (oppId && oppId.toLowerCase() !== 'n/a' && oppId.toLowerCase() !== 'undefined') {
-    applyLink = `https://www.grants.gov/search-results-detail/${oppId}`;
+  if (directLinkFromApi && (directLinkFromApi.startsWith('http://') || directLinkFromApi.startsWith('https://'))) {
+    applyLink = directLinkFromApi;
+  } else if (oppId && oppId.toLowerCase() !== 'n/a' && oppId.toLowerCase() !== 'undefined') {
+    // Fallback to a common Grants.gov opportunity view URL structure
+    applyLink = `https://www.grants.gov/web/grants/view-opportunity.html?oppId=${oppId}`;
   }
 
   return {


### PR DESCRIPTION
Updates the `_mapFetchedOpportunityToGrant` function to improve the generation of the `linkToApply` field for grant details.

- Prioritizes using the `link` field directly from the `data.synopsis.link` part of the `fetchOpportunity` API response if it is a valid absolute URL.
- If `synopsis.link` is not available or invalid, it falls back to constructing a URL using the `https://www.grants.gov/web/grants/view-opportunity.html?oppId=` format, which is a more direct view link than the previously used `search-results-detail/` path for this specific context.
- Ensures a fallback to `https://www.grants.gov` if no valid ID or link can be determined.