### PR TITLE
fix: Standardize grant link format to search-results-detail

### DIFF
--- a/app/services/grantsGovService.ts
+++ b/app/services/grantsGovService.ts
@@ -113,20 +113,18 @@ function _mapFetchedOpportunityToGrant(apiDetailResponse: any): Grant {
     }
   }
 
-  // LinkToApply generation
+  // LinkToApply generation - Standardized based on user feedback
   let applyLink = 'https://www.grants.gov'; // Default fallback
-  const directLinkFromApi = synopsis?.link; // From fetchOpportunity sample: data.synopsis.link
-  const oppId = grantData?.opportunityId?.toString();
+  // grantData is apiDetailResponse.data. The numeric ID is grantData.id as per fetchOpportunity sample.
+  const numericIdFromApi = grantData?.id?.toString(); 
 
-  if (directLinkFromApi && (directLinkFromApi.startsWith('http://') || directLinkFromApi.startsWith('https://'))) {
-    applyLink = directLinkFromApi;
-  } else if (oppId && oppId.toLowerCase() !== 'n/a' && oppId.toLowerCase() !== 'undefined') {
-    // Fallback to a common Grants.gov opportunity view URL structure
-    applyLink = `https://www.grants.gov/web/grants/view-opportunity.html?oppId=${oppId}`;
+  if (numericIdFromApi && numericIdFromApi.toLowerCase() !== 'n/a' && numericIdFromApi.toLowerCase() !== 'undefined' && /^[0-9]+$/.test(numericIdFromApi)) {
+    // Ensure it's purely numeric, as it's used in the URL path segment
+    applyLink = `https://www.grants.gov/search-results-detail/${numericIdFromApi}`;
   }
 
   return {
-    id: grantData?.opportunityId?.toString() || "N/A",
+    id: grantData?.opportunityId?.toString() || "N/A", // This is the main alphanumeric Opportunity ID
     title: grantData?.opportunityTitle || "N/A",
     agency: synopsis?.agencyName || grantData?.owningAgencyCode || "N/A",
     description: sanitizeHtmlContent(synopsis?.synopsisDesc || "No detailed description available."),


### PR DESCRIPTION
Ensures that the "Apply Here" link on the grant detail page consistently uses the `https://www.grants.gov/search-results-detail/{ID}` URL structure, utilizing the numeric `id` field (e.g., 289999) from the `fetchOpportunity` API response's `data` object.

This aligns the detail page link format with the links used on the search results grant cards and with specific user feedback. The mapping in `_mapFetchedOpportunityToGrant` was updated accordingly. No changes were needed for the search results link mapping (`_mapOppHitToGrant`) as it already used this format.