### PR TITLE
feat: Prefill search bar on grants page

### DIFF
--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -6,10 +6,11 @@ import { Button } from "@/components/ui/button"; // Verify path
 
 interface SearchBarProps {
   onSearch: (searchTerm: string) => void;
+  initialValue?: string;
 }
 
-const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
-  const [searchTerm, setSearchTerm] = useState("");
+const SearchBar: React.FC<SearchBarProps> = ({ onSearch, initialValue }) => {
+  const [searchTerm, setSearchTerm] = useState(initialValue || "");
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();

--- a/app/grants/GrantsPageClient.tsx
+++ b/app/grants/GrantsPageClient.tsx
@@ -143,7 +143,7 @@ export default function GrantsPageClient({
         </h1>
       </header>
 
-      <SearchBar onSearch={handleSearch} />
+      <SearchBar onSearch={handleSearch} initialValue={initialSearchTerm} />
       <FilterControls onApplyFilters={handleApplyFilters} />
 
       <section className="mt-8">


### PR DESCRIPTION
This change ensures that when a search is initiated from the home page and you are redirected to the /grants page, the search bar on the /grants page is pre-filled with the search term.

Modifications:
- Added an `initialValue` prop to the `SearchBar.tsx` component to allow setting its initial displayed value.
- Updated `GrantsPageClient.tsx` to pass the `initialSearchTerm` (received from server-side props, originating from the URL query param) to the `SearchBar`'s `initialValue` prop.

This addresses the issue where the grants page would show results based on the URL query but the search input itself would be empty, making the search state unclear to you.