### PR TITLE
fix: Resolve client-side search and pagination on grants page

### DIFF
--- a/app/api/grants/search/route.ts
+++ b/app/api/grants/search/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+import { mapGrantsGovGrantToGrant } from '../../../lib/grant-mapping';
+import type { Grant, GrantsGovResponse, GrantsGovGrant } from '../../../types';
 
 const STAGING_API_URL = "https://api.grants.gov/v1/api";
 
@@ -16,19 +18,38 @@ export async function POST(request: Request) {
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error('Grants.gov API Error:', response.status, errorText);
+      console.error('Grants.gov API Error (Network):', response.status, errorText);
       return NextResponse.json(
         { error: `API request failed with status ${response.status}: ${errorText}` },
         { status: response.status }
       );
     }
 
-    const data = await response.json();
-    return NextResponse.json(data);
+    const data: GrantsGovResponse = await response.json();
+
+    // Error Handling (Grants.gov specific)
+    if (data.errorcode !== 0 || !data.data || !data.data.oppHits) {
+      console.error('Grants.gov API Logic Error:', data.msg, data.errorcode);
+      return NextResponse.json(
+        { error: `Grants.gov API Error: ${data.msg || 'Unknown error'} (code: ${data.errorcode})` },
+        { status: 400 } // Bad Request, as the API itself reported an issue with the request or data.
+      );
+    }
+
+    // Data Mapping
+    const oppHits: GrantsGovGrant[] = data.data.oppHits;
+    const mappedGrants: Grant[] = oppHits.map(mapGrantsGovGrantToGrant);
+    const totalRecords: number = data.data.hitCount;
+
+    // Return Mapped Data
+    return NextResponse.json({ grants: mappedGrants, totalRecords: totalRecords });
+
   } catch (error) {
     console.error('Error in search API route:', error);
+    // Check if error is an instance of Error to safely access message property
+    const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred';
     return NextResponse.json(
-      { error: 'Failed to fetch data from Grants.gov API' },
+      { error: `Failed to fetch data from Grants.gov API: ${errorMessage}` },
       { status: 500 }
     );
   }

--- a/app/lib/grant-mapping.ts
+++ b/app/lib/grant-mapping.ts
@@ -1,0 +1,31 @@
+// app/lib/grant-mapping.ts
+import type { Grant, GrantsGovGrant, GrantsGovData } from "../../types"; // GrantsGovData might not be directly used by the moved function but is good for context
+
+// Renamed and exported function from grantsGovService.ts
+export function mapGrantsGovGrantToGrant(apiGrant: GrantsGovGrant): Grant {
+  return {
+    id: apiGrant.id,
+    title: apiGrant.title,
+    agency: apiGrant.agency,
+    description: `Synopsis for ${apiGrant.title}. More details available.`,
+    eligibilityCriteria: "Varies; see full announcement.",
+    deadline: apiGrant.closeDate || "N/A",
+    amount: 0, // Defaulting amount as it's not in GrantsGovGrant (oppHit)
+    linkToApply: `https://www.grants.gov/search-results-detail/${apiGrant.id}`,
+    sourceAPI: "Grants.gov",
+    opportunityNumber: apiGrant.number,
+    opportunityStatus: apiGrant.oppStatus,
+    postedDate: apiGrant.openDate || "N/A",
+    categories: apiGrant.alnist || [], // Assuming alnist maps to categories
+  };
+}
+
+// If GrantsGovData is indeed part of GrantsGovResponse and used by other potential mapping functions,
+// it's good it's imported. If not, it can be removed.
+// For now, keeping the import as specified in the plan.
+// Also, ensure GrantsGovResponse is imported if other functions in this file might need it.
+// Based on the task, only Grant and GrantsGovGrant are directly used by mapGrantsGovGrantToGrant.
+// Adding GrantsGovData for completeness as per step 2 of the overall task.
+// The type GrantsGovResponse itself isn't used in this specific file yet.
+// export type { Grant, GrantsGovGrant, GrantsGovData }; // Re-exporting types if needed elsewhere, but direct import is cleaner.
+// For now, direct imports in files that need them is the strategy.


### PR DESCRIPTION
This commit addresses issues on the /grants page where client-side searches and pagination would result in no grants being displayed.

The core problem was a mismatch in the expected data structure. GrantsPageClient.tsx expected a mapped format like `{ grants: [], totalRecords: 0 }`, but the `/api/grants/search` endpoint was returning the raw, nested data from the external Grants.gov API.

Changes:
1.  Centralized Data Mapping:
    -   Moved grant mapping logic (`_mapOppHitToGrant` renamed to
        `mapGrantsGovGrantToGrant` and related types) to a new shared
        utility file: `app/lib/grant-mapping.ts`.
2.  API Route Modification:
    -   Updated `/api/grants/search/route.ts` to use the shared mapping
        utility. It now processes the raw response from Grants.gov and
        returns the data in the consistent application format:
        `{ grants: Grant[], totalRecords: number }`.
    -   Enhanced error handling in this route for Grants.gov specific errors.
3.  Service Layer Adjustment:
    -   Simplified the `searchGrants` function in
        `app/services/grantsGovService.ts`. Since the API route it calls
        now returns pre-mapped data, `searchGrants` no longer needs to
        perform mapping itself.

With these changes, `GrantsPageClient.tsx` now receives the correctly structured data for its client-side operations (new searches, filter applications, pagination), resolving the bugs.